### PR TITLE
Add modified MPlayer Portfile to fix build errors

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -1,0 +1,71 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:filetype=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                MPlayer
+conflicts           mplayer-devel
+version             1.5.0
+distname            ${name}-1.5
+livecheck.version   1.5
+revision            2
+categories          multimedia
+license             GPL-2+
+maintainers         {jeremyhu @jeremyhu} openmaintainer
+
+description         versatile movie player
+long_description    ${name} plays most movie files in popular and less popular formats.
+
+homepage            https://www.mplayerhq.hu/
+master_sites        https://mplayerhq.hu/MPlayer/releases/
+use_xz              yes
+
+checksums           rmd160  9de00488978d8774310d2884a4784674e64f4abc \
+                    sha256  650cd55bb3cb44c9b39ce36dac488428559799c5f18d16d98edb2b7256cbbf85 \
+                    size    15379972
+
+depends_build-append \
+                    port:pkgconfig \
+                    port:yasm
+
+depends_lib-append  path:include/turbojpeg.h:libjpeg-turbo \
+                    path:lib/libspeex.dylib:speex \
+                    path:lib/pkgconfig/gnutls.pc:gnutls \
+                    port:aom \
+                    port:bzip2 \
+                    port:dav1d \
+                    port:fontconfig \
+                    port:freetype \
+                    port:fribidi \
+                    port:lame \
+                    port:libiconv \
+                    port:libpng \
+                    port:libxml2 \
+                    port:lzo2 \
+                    port:ncurses \
+                    port:zlib
+
+# https://trac.macports.org/ticket/70804
+# This fix breaks at least Leopard if not Snow as well, so it has been commented out.
+#if {${os.platform} eq "darwin" && ${os.version} > 22} {
+#    configure.cflags-append -Wno-error=incompatible-function-pointer-types -Wno-error=int-conversion
+#}
+
+configure.args      --cc=${configure.cc} \
+                    --host-cc=${configure.cc} \
+                    --enable-freetype \
+                    --enable-menu
+
+
+foreach option {
+
+3dfx aa alsa apple-ir arts bl bluray caca cddb cdparanoia dart dga1 dga2 direct3d directfb \
+directx dvb dvdnav dvdread dxr2 dxr3 esd faac faad fbdev ggi gif gui jack joystick kai kva \
+ladspa liba52 libbs2b libdca libdv libnut libvorbis lirc live macosx-finder mad mga mng \
+mpg123 musepack nas nemesi ossaudio pulse pvr qtx quartz radio  radio-capture  s3fb sdl \
+sgiaudio smb sndio sunaudio svga tdfxfb tdfxvid theora toolame  tv-bsdbt848 tv-dshow \
+tv-v4l1 tv-v4l2 twolame v4l2 vdpau vesa vidix vstream wii win32dll win32waveout x11 \
+x264 xmga xmms xv xvid xvmc xvr100 zr
+
+} {
+    configure.args-append --disable-${option}
+}


### PR DESCRIPTION
This PR includes a fixed Portfile for the MPlayer package to allow for a correct build on PowerPC.

A fix allowing the port to build on macOS Sequoia (https://trac.macports.org/ticket/70804) breaks builds on at least Leopard if not also Snow Leopard, so it has been commented out.

The patch for i386 builds has also been removed as it's out of scope.